### PR TITLE
ci: add pre-commit workflow

### DIFF
--- a/.github/pre-commit.yml
+++ b/.github/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
This will help us ensure pre-commit is still clean on PRs to main and in main itself.