### PR TITLE
refactor: change return type of get_connection method to Generator

### DIFF
--- a/mcp_server_snowflake/connection.py
+++ b/mcp_server_snowflake/connection.py
@@ -12,8 +12,9 @@
 import json
 import logging
 from contextlib import contextmanager
-from typing import Optional, Dict, Any, Tuple
-from snowflake.connector import connect, DictCursor
+from typing import Any, Dict, Generator, Optional, Tuple
+
+from snowflake.connector import DictCursor, connect
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +82,7 @@ class SnowflakeConnectionManager:
         session_parameters: Optional[Dict[str, Any]] = None,
         use_dict_cursor: bool = False,
         **kwargs: Any,
-    ) -> Tuple[Any, Any]:
+    ) -> Generator[Tuple[Any, Any], None, None]:
         """
         Get a Snowflake connection with the specified configuration.
 


### PR DESCRIPTION
fixing type hints for the context manager pattern. 

Resolves #23 

pyright was showing me the following:

Argument of type "(self: Self@SnowflakeConnectionManager, session_parameters: Dict[str, Any] | None = None, use_dict_cursor: bool = False, **kwargs: Any) -> Tuple[Any, Any]" cannot be assigned to parameter "func" of type "(**_P@contextmanager) -> Iterator[_T_co@contextmanager]" in function "contextmanager"
  Type "(self: Self@SnowflakeConnectionManager, session_parameters: Dict[str, Any] | None = None, use_dict_cursor: bool = False, **kwargs: Any) -> Tuple[Any, Any]" is not assignable to type "(**_P@contextmanager) -> Iterator[_T_co@contextmanager]"
    Function return type "Tuple[Any, Any]" is incompatible with type "Iterator[_T_co@contextmanager]"
      "Tuple[Any, Any]" is incompatible with protocol "Iterator[_T_co@contextmanager]"
        "__next__" is not presentbasedpyright[reportArgumentType](https://docs.basedpyright.com/v1.28.5/configuration/config-files/#reportArgumentType)Argument of type "(self: Self@SnowflakeConnectionManager, session_parameters: Dict[str, Any] | None = None, use_dict_cursor: bool = False, **kwargs: Any) -> Tuple[Any, Any]" cannot be assigned to parameter "func" of type "(**_P@contextmanager) -> Iterator[_T_co@contextmanager]" in function "contextmanager"
  Type "(self: Self@SnowflakeConnectionManager, session_parameters: Dict[str, Any] | None = None, use_dict_cursor: bool = False, **kwargs: Any) -> Tuple[Any, Any]" is not assignable to type "(**_P@contextmanager) -> Iterator[_T_co@contextmanager]"
    Function return type "Tuple[Any, Any]" is incompatible with type "Iterator[_T_co@contextmanager]"
      "Tuple[Any, Any]" is incompatible with protocol "Iterator[_T_co@contextmanager]"
        "__next__" is not presentbasedpyright[reportArgumentType](https://docs.basedpyright.com/v1.28.5/configuration/config-files/#reportArgumentType)Argument of type "(self: Self@SnowflakeConnectionManager, session_parameters: Dict[str, Any] | None = None, use_dict_cursor: bool = False, **kwargs: Any) -> Tuple[Any, Any]" cannot be assigned to parameter "func" of type "(**_P@contextmanager) -> Iterator[_T_co@contextmanager]" in function "contextmanager"
  Type "(self: Self@SnowflakeConnectionManager, session_parameters: Dict[str, Any] | None = None, use_dict_cursor: bool = False, **kwargs: Any) -> Tuple[Any, Any]" is not assignable to type "(**_P@contextmanager) -> Iterator[_T_co@contextmanager]"
    Function return type "Tuple[Any, Any]" is incompatible with type "Iterator[_T_co@contextmanager]"
      "Tuple[Any, Any]" is incompatible with protocol "Iterator[_T_co@contextmanager]"
        "__next__" is not presentbasedpyright[reportArgumentType](https://docs.basedpyright.com/v1.28.5/configuration/config-files/#reportArgumentType)