### PR TITLE
style(ruff): add T201 rule to Ruff configuration

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -39,7 +39,7 @@ target-version = "py310"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F", "I"]
+select = ["E4", "E7", "E9", "F", "I", "T201"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/print/

This will prevent scenarios where we are old-school debugging and need to avoid committing. 