### PR TITLE
Auth refactor

### DIFF
--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -181,10 +181,9 @@ class SnowflakeService:
             }
         else:
             return {
-                "X-Snowflake-Authorization-Token-Type": "PROGRAMMATIC_ACCESS_TOKEN",
-                "Authorization": f"Bearer {self.get_token()}",
-                "Content-Type": "application/json",
                 "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json",
+                "Authorization": f'Snowflake Token="{self.get_token()}"',
             }
 
     def get_token(self) -> str:

--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -73,6 +73,8 @@ class SnowflakeService:
         List of configured analyst service specifications
     agent_services : list
         List of configured agent service specifications
+    connection : snowflake.connector.Connection
+        Snowflake connection object
     """
 
     def __init__(
@@ -97,6 +99,8 @@ class SnowflakeService:
         self.set_query_tag(
             major_version=tag_major_version, minor_version=tag_minor_version
         )
+        # Persist connection to avoid closing it after each request
+        self.connection = self._get_persistent_connection()
 
     def unpack_service_specs(self) -> None:
         """
@@ -193,8 +197,7 @@ class SnowflakeService:
         if self._is_spcs_container:
             return get_spcs_container_token()
         else:
-            with self.get_connection() as (con, cur):
-                return con.rest.token
+            return self.connection.rest.token
 
     def get_api_host(self) -> str:
         """
@@ -214,6 +217,37 @@ class SnowflakeService:
     def is_spcs_container_environment(self) -> bool:
         """Check if running in SPCS container environment."""
         return self._is_spcs_container
+
+    def _get_persistent_connection(
+        self,
+        session_parameters: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """
+        Get a persistent Snowflake connection.
+
+        This method creates a connection that will be kept alive and should be
+        explicitly closed when no longer needed.
+
+        Parameters
+        ----------
+        session_parameters : dict, optional
+            Additional session parameters to add to connection
+
+        Returns
+        -------
+        connection
+            A Snowflake connection object
+        """
+        try:
+            connection = connect(
+                **self.connection_params,
+                session_parameters=session_parameters,
+                client_session_keep_alive=True,
+            )
+            return connection
+        except Exception as e:
+            logger.error(f"Error establishing persistent Snowflake connection: {e}")
+            raise
 
     @contextmanager
     def get_connection(
@@ -241,17 +275,16 @@ class SnowflakeService:
 
         Examples
         --------
-        >>> with service.get_connection(
-        ...     role="ANALYST", warehouse="COMPUTE_WH", use_dict_cursor=True
-        ... ) as (con, cur):
+        >>> with service.get_connection(use_dict_cursor=True) as (con, cur):
         ...     cur.execute("SELECT current_version()")
         ...     result = cur.fetchone()
         """
 
         try:
-            # connection_params = self.connection_params.copy()
             connection = connect(
-                **self.connection_params, session_parameters=session_parameters
+                **self.connection_params,
+                session_parameters=session_parameters,
+                client_session_keep_alive=False,
             )
 
             cursor = (
@@ -507,14 +540,18 @@ def initialize_tools(snowflake_service):
 
 
 def main():
-    snowflake_service = create_snowflake_service()
-    initialize_tools(snowflake_service)
-    initialize_resources(snowflake_service)
+    try:
+        snowflake_service = create_snowflake_service()
+        initialize_tools(snowflake_service)
+        initialize_resources(snowflake_service)
 
-    if snowflake_service.transport in ["sse", "streamable-http"]:
-        server.run(transport=snowflake_service.transport, host="0.0.0.0", port=9000)
-    else:
-        server.run(transport=snowflake_service.transport)
+        if snowflake_service.transport in ["sse", "streamable-http"]:
+            server.run(transport=snowflake_service.transport, host="0.0.0.0", port=9000)
+        else:
+            server.run(transport=snowflake_service.transport)
+    finally:
+        if snowflake_service.connection:
+            snowflake_service.connection.close()
 
 
 if __name__ == "__main__":

--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -220,6 +220,7 @@ class SnowflakeService:
     def get_connection(
         self,
         use_dict_cursor: bool = False,
+        session_parameters: Optional[Dict[str, Any]] = None,
     ) -> Generator[Tuple[Any, Any], None, None]:
         """
         Get a Snowflake connection with the specified configuration.
@@ -231,6 +232,8 @@ class SnowflakeService:
         ----------
         use_dict_cursor : bool, default=False
             Whether to use DictCursor instead of regular cursor
+        session_parameters : dict, optional
+            Additional session parameters to add to connection such as query tag
 
         Yields
         ------
@@ -247,7 +250,10 @@ class SnowflakeService:
         """
 
         try:
-            connection = connect(**self.connection_params)
+            # connection_params = self.connection_params.copy()
+            connection = connect(
+                **self.connection_params, session_parameters=session_parameters
+            )
 
             cursor = (
                 connection.cursor(DictCursor)
@@ -287,11 +293,14 @@ class SnowflakeService:
             query_tag["version"] = {"major": major_version, "minor": minor_version}
 
         # Set the query tag in default session parameters
-        self.default_session_parameters["QUERY_TAG"] = json.dumps(query_tag)
+        session_parameters = {"QUERY_TAG": json.dumps(query_tag)}
 
         try:
             # Test connection with the query tag
-            with self.get_connection() as (con, cur):
+            with self.get_connection(session_parameters=session_parameters) as (
+                con,
+                cur,
+            ):
                 cur.execute("SELECT 1").fetchone()
         except Exception as e:
             logger.warning(f"Error setting query tag: {e}")

--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -35,7 +35,7 @@ from mcp_server_snowflake.utils import (
 # Used to quantify Snowflake usage
 server_name = "mcp-server-snowflake"
 tag_major_version = 0
-tag_minor_version = 3
+tag_minor_version = 4
 query_tag = {"origin": "sf_sit", "name": "mcp_server"}
 
 logger = logging.getLogger(server_name)

--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -54,25 +54,15 @@ class SnowflakeService:
 
     Parameters
     ----------
-    account_identifier : str
-        Snowflake account identifier
-    username : str
-        Snowflake username for authentication
-    pat : str
-        Programmatic Access Token for Snowflake authentication
     service_config_file : str
         Path to the service configuration YAML file
     transport : str
         Transport for the MCP server
+    connection_params : dict
+        Connection parameters for Snowflake connector
 
     Attributes
     ----------
-    account_identifier : str
-        Snowflake account identifier
-    username : str
-        Snowflake username
-    pat : str
-        Programmatic Access Token
     service_config_file : str
         Path to configuration file
     transport : Literal["stdio", "sse", "streamable-http"]
@@ -83,24 +73,18 @@ class SnowflakeService:
         List of configured analyst service specifications
     agent_services : list
         List of configured agent service specifications
-    default_session_parameters : dict
-        Default session parameters to apply to all connections
     """
 
     def __init__(
         self,
-        account_identifier: str,
-        username: str,
-        pat: str,
         service_config_file: str,
         transport: str,
+        connection_params: dict,
     ):
-        self.account_identifier = account_identifier
-        self.username = username
-        self.pat = pat
         self.service_config_file = str(Path(service_config_file).expanduser().resolve())
         self.config_path_uri = Path(self.service_config_file).as_uri()
         self.transport = cast(Literal["stdio", "sse", "streamable-http"], transport)
+        self.connection_params = connection_params
         self.search_services = []
         self.analyst_services = []
         self.agent_services = []
@@ -108,14 +92,6 @@ class SnowflakeService:
 
         # Environment detection for authentication
         self._is_spcs_container = is_running_in_spcs_container()
-
-        # Validate required parameters for external environment
-        if not self._is_spcs_container:
-            if not all([account_identifier, username, pat]):
-                raise ValueError(
-                    "When running outside a Snowflake SPCS container, "
-                    "account_identifier, username, and pat are required"
-                )
 
         self.unpack_service_specs()
         self.set_query_tag(
@@ -155,39 +131,38 @@ class SnowflakeService:
             logger.error(f"Error extracting service specifications: {e}")
             raise
 
-    def get_connection_params(self, **kwargs) -> Dict[str, Any]:
-        """
-        Get connection parameters for snowflake.connector.connect().
+    # def get_connection_params(self) -> Dict[str, Any]:
+    #     """
+    #     Get connection parameters for snowflake.connector.connect().
 
-        Parameters
-        ----------
-        **kwargs
-            Additional connection parameters
+    #     Parameters
+    #     ----------
 
-        Returns
-        -------
-        Dict[str, Any]
-            Connection parameters
-        """
-        if self._is_spcs_container:
-            logger.info("Using SPCS container OAuth authentication")
-            params = {
-                "host": os.getenv("SNOWFLAKE_HOST"),
-                "account": os.getenv("SNOWFLAKE_ACCOUNT"),
-                "token": get_spcs_container_token(),
-                "authenticator": "oauth",
-            }
-            params = {k: v for k, v in params.items() if v is not None}
-        else:
-            logger.info("Using external PAT authentication")
-            params = {
-                "account": self.account_identifier,
-                "user": self.username,
-                "password": self.pat,
-            }
+    #     Returns
+    #     -------
+    #     Dict[str, Any]
+    #         Connection parameters
+    #     """
+    #     if self._is_spcs_container:
+    #         logger.info("Using SPCS container OAuth authentication")
 
-        params.update(kwargs)
-        return params
+    #         params = {
+    #             "host": os.getenv("SNOWFLAKE_HOST"),
+    #             "account": os.getenv("SNOWFLAKE_ACCOUNT"),
+    #             "token": get_spcs_container_token(),
+    #             "authenticator": "oauth",
+    #         }
+    #         params = {k: v for k, v in params.items() if v is not None}
+    #     else:
+    #         logger.info("Using external PAT authentication")
+    #         params = {
+    #             "account": self.account_identifier,
+    #             "user": self.username,
+    #             "password": self.pat,
+    #         }
+
+    # params.update(kwargs)
+    # return params
 
     def get_api_headers(self) -> Dict[str, str]:
         """
@@ -200,17 +175,27 @@ class SnowflakeService:
         """
         if self._is_spcs_container:
             return {
-                "Authorization": f"Bearer {get_spcs_container_token()}",
+                "Authorization": f"Bearer {self.get_token()}",
                 "Content-Type": "application/json",
                 "Accept": "application/json, text/event-stream",
             }
         else:
             return {
                 "X-Snowflake-Authorization-Token-Type": "PROGRAMMATIC_ACCESS_TOKEN",
-                "Authorization": f"Bearer {self.pat}",
+                "Authorization": f"Bearer {self.get_token()}",
                 "Content-Type": "application/json",
                 "Accept": "application/json, text/event-stream",
             }
+
+    def get_token(self) -> str:
+        """
+        Get the connection token for the Snowflake service.
+        """
+        if self._is_spcs_container:
+            return get_spcs_container_token()
+        else:
+            with self.get_connection() as (con, cur):
+                return con.rest.token
 
     def get_api_host(self) -> str:
         """
@@ -222,9 +207,9 @@ class SnowflakeService:
             API host URL
         """
         if self._is_spcs_container:
-            return os.getenv("SNOWFLAKE_HOST", self.account_identifier)
+            return os.getenv("SNOWFLAKE_HOST", self.connection_params.get("account"))
         else:
-            return self.account_identifier
+            return self.connection_params.get("account")
 
     @property
     def is_spcs_container_environment(self) -> bool:
@@ -234,9 +219,7 @@ class SnowflakeService:
     @contextmanager
     def get_connection(
         self,
-        session_parameters: Optional[Dict[str, Any]] = None,
         use_dict_cursor: bool = False,
-        **kwargs: Any,
     ) -> Generator[Tuple[Any, Any], None, None]:
         """
         Get a Snowflake connection with the specified configuration.
@@ -246,12 +229,8 @@ class SnowflakeService:
 
         Parameters
         ----------
-        session_parameters : dict, optional
-            Additional session parameters to merge with defaults
         use_dict_cursor : bool, default=False
             Whether to use DictCursor instead of regular cursor
-        **kwargs : Any
-            Additional connection parameters (e.g., role, warehouse) to pass to connect()
 
         Yields
         ------
@@ -266,17 +245,9 @@ class SnowflakeService:
         ...     cur.execute("SELECT current_version()")
         ...     result = cur.fetchone()
         """
-        # Merge default and provided session parameters
-        merged_params = self.default_session_parameters.copy()
-        if session_parameters:
-            merged_params.update(session_parameters)
 
         try:
-            # Get connection parameters based on environment
-            connection_params = self.get_connection_params(**kwargs)
-            connection_params["session_parameters"] = merged_params
-
-            connection = connect(**connection_params)
+            connection = connect(**self.connection_params)
 
             cursor = (
                 connection.cursor(DictCursor)
@@ -391,24 +362,49 @@ def create_snowflake_service():
 
     Notes
     -----
-    The server requires these minimum parameters:
-    - account_identifier: Snowflake account identifier
-    - username: Snowflake username
-    - pat: Programmatic Access Token for authentication
-    - service_config_file: Path to service configuration file
+    The server uses the Snowflake Python connector to establish a connection to Snowflake.
+    - See https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect
+    for connection parameters.
+    - service_config_file is also required as the path to the service configuration file
 
     """
     parser = argparse.ArgumentParser(description="Snowflake MCP Server")
 
-    parser.add_argument(
-        "--account-identifier", required=False, help="Snowflake account identifier"
-    )
-    parser.add_argument(
-        "--username", required=False, help="Username for Snowflake account"
-    )
-    parser.add_argument(
-        "--pat", required=False, help="Programmatic Access Token (PAT) for Snowflake"
-    )
+    # Dict of login params supported by snowflake connector api to establish connection
+    # {Key value name : [argparse argument name, default value]}
+    login_params = {  # TODO: Add help for each argument
+        "account": [
+            "--account",
+            "--account-identifier",
+            os.getenv("SNOWFLAKE_ACCOUNT"),
+        ],
+        "host": ["--host", os.getenv("SNOWFLAKE_HOST")],
+        "user": ["--user", "--username", os.getenv("SNOWFLAKE_USER")],
+        "password": [
+            "--password",
+            "--pat",
+            os.getenv("SNOWFLAKE_PASSWORD") or os.getenv("SNOWFLAKE_PAT"),
+        ],
+        "role": ["--role", os.getenv("SNOWFLAKE_ROLE")],
+        "warehouse": ["--warehouse", os.getenv("SNOWFLAKE_WAREHOUSE")],
+        "passcode_in_password": ["--passcode-in-password", False],
+        "passcode": ["--passcode", os.getenv("SNOWFLAKE_PASSCODE")],
+        "private_key": ["--private-key", os.getenv("SNOWFLAKE_PRIVATE_KEY")],
+        "private_key_file": [
+            "--private-key-file",
+            os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE"),
+        ],
+        "private_key_pwd": [
+            "--private-key-pwd",
+            os.getenv("SNOWFLAKE_PRIVATE_KEY_PWD"),
+        ],
+        "authenticator": ["--authenticator", "snowflake"],
+        "connection_name": ["--connection-name", None],
+    }
+
+    for value in login_params.values():
+        parser.add_argument(*value[:-1], required=False, default=value[-1])
+
     parser.add_argument(
         "--service-config-file",
         required=False,
@@ -423,34 +419,30 @@ def create_snowflake_service():
     )
 
     args = parser.parse_args()
-    account_identifier = get_var("account_identifier", "SNOWFLAKE_ACCOUNT", args)
-    username = get_var("username", "SNOWFLAKE_USER", args)
-    pat = get_var("pat", "SNOWFLAKE_PAT", args)
+    connection_params = {
+        key: getattr(args, key)
+        for key in login_params.keys()
+        if getattr(args, key) is not None
+    }
     service_config_file = get_var("service_config_file", "SERVICE_CONFIG_FILE", args)
 
-    parameters = dict(
-        account_identifier=account_identifier,
-        username=username,
-        pat=pat,
-        service_config_file=service_config_file,
-        transport=args.transport,
-    )
-
-    if not all(parameters.values()):
+    required = {
+        "service_config_file": service_config_file,
+    }
+    if not all(required.values()):
         raise MissingArgumentsException(
-            missing=[k for k, v in parameters.items() if not v]
+            missing=[k for k, v in required.items() if not v]
         ) from None
-    else:
-        # Type assertion since we've validated all values are not None
+    try:
         snowflake_service = SnowflakeService(
-            account_identifier=account_identifier or "",
-            username=username or "",
-            pat=pat or "",
-            service_config_file=service_config_file or "",
+            service_config_file=service_config_file,
             transport=args.transport,
+            connection_params=connection_params,
         )
-
         return snowflake_service
+    except Exception as e:
+        logger.error(f"Error creating Snowflake service: {e}")
+        raise
 
 
 server = FastMCP("Snowflake MCP Server")

--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -32,9 +32,11 @@ from mcp_server_snowflake.utils import (
     load_tools_config_resource,
 )
 
+# Used to quantify Snowflake usage
 server_name = "mcp-server-snowflake"
 tag_major_version = 0
 tag_minor_version = 3
+query_tag = {"origin": "sf_sit", "name": "mcp_server"}
 
 logger = logging.getLogger(server_name)
 
@@ -91,14 +93,19 @@ class SnowflakeService:
         self.analyst_services = []
         self.agent_services = []
         self.default_session_parameters: Dict[str, Any] = {}
+        self.query_tag = query_tag if query_tag is not None else None
+        self.tag_major_version = (
+            tag_major_version if tag_major_version is not None else None
+        )
+        self.tag_minor_version = (
+            tag_minor_version if tag_minor_version is not None else None
+        )
 
         # Environment detection for authentication
         self._is_spcs_container = is_running_in_spcs_container()
 
         self.unpack_service_specs()
-        self.set_query_tag(
-            major_version=tag_major_version, minor_version=tag_minor_version
-        )
+        self.set_query_tag()
         # Persist connection to avoid closing it after each request
         self.connection = self._get_persistent_connection()
 
@@ -134,39 +141,6 @@ class SnowflakeService:
         except Exception as e:
             logger.error(f"Error extracting service specifications: {e}")
             raise
-
-    # def get_connection_params(self) -> Dict[str, Any]:
-    #     """
-    #     Get connection parameters for snowflake.connector.connect().
-
-    #     Parameters
-    #     ----------
-
-    #     Returns
-    #     -------
-    #     Dict[str, Any]
-    #         Connection parameters
-    #     """
-    #     if self._is_spcs_container:
-    #         logger.info("Using SPCS container OAuth authentication")
-
-    #         params = {
-    #             "host": os.getenv("SNOWFLAKE_HOST"),
-    #             "account": os.getenv("SNOWFLAKE_ACCOUNT"),
-    #             "token": get_spcs_container_token(),
-    #             "authenticator": "oauth",
-    #         }
-    #         params = {k: v for k, v in params.items() if v is not None}
-    #     else:
-    #         logger.info("Using external PAT authentication")
-    #         params = {
-    #             "account": self.account_identifier,
-    #             "user": self.username,
-    #             "password": self.pat,
-    #         }
-
-    # params.update(kwargs)
-    # return params
 
     def get_api_headers(self) -> Dict[str, str]:
         """
@@ -221,6 +195,8 @@ class SnowflakeService:
     def _get_persistent_connection(
         self,
         session_parameters: Optional[Dict[str, Any]] = None,
+        major_version: Optional[int] = None,
+        minor_version: Optional[int] = None,
     ) -> Any:
         """
         Get a persistent Snowflake connection.
@@ -232,6 +208,10 @@ class SnowflakeService:
         ----------
         session_parameters : dict, optional
             Additional session parameters to add to connection
+        major_version : int, optional
+            Major version of the query tag
+        minor_version : int, optional
+            Minor version of the query tag
 
         Returns
         -------
@@ -239,6 +219,11 @@ class SnowflakeService:
             A Snowflake connection object
         """
         try:
+            if session_parameters is not None:
+                session_parameters.update(self.get_query_tag_param())
+            else:
+                session_parameters = self.get_query_tag_param()
+
             connection = connect(
                 **self.connection_params,
                 session_parameters=session_parameters,
@@ -303,11 +288,41 @@ class SnowflakeService:
             logger.error(f"Error establishing Snowflake connection: {e}")
             raise
 
+    def get_query_tag_param(
+        self,
+    ) -> Optional[Dict[str, Any]] | None:
+        """
+        Get the query tag parameters for the Snowflake service.
+
+        Parameters
+        ----------
+        query_tag : dict[str, str], optional
+            Query tag dictionary
+        major_version : int, optional
+            Major version of the query tag
+        minor_version : int, optional
+            Minor version of the query tag
+        """
+        if self.query_tag is not None:
+            query_tag = self.query_tag.copy()
+            if (
+                self.tag_major_version is not None
+                and self.tag_minor_version is not None
+            ):
+                query_tag["version"] = {
+                    "major": self.tag_major_version,
+                    "minor": self.tag_minor_version,
+                }
+
+            # Set the query tag in default session parameters
+            session_parameters = {"QUERY_TAG": json.dumps(query_tag)}
+
+            return session_parameters
+        else:
+            return None
+
     def set_query_tag(
         self,
-        query_tag: dict[str, str | dict] = {"origin": "sf_sit", "name": "mcp_server"},
-        major_version: Optional[int] = None,
-        minor_version: Optional[int] = None,
     ) -> None:
         """
         Set the query tag for the Snowflake service.
@@ -321,11 +336,8 @@ class SnowflakeService:
         minor_version : int, optional
             Minor version of the query tag
         """
-        if major_version is not None and minor_version is not None:
-            query_tag["version"] = {"major": major_version, "minor": minor_version}
 
-        # Set the query tag in default session parameters
-        session_parameters = {"QUERY_TAG": json.dumps(query_tag)}
+        session_parameters = self.get_query_tag_param()
 
         try:
             # Test connection with the query tag

--- a/mcp_server_snowflake/tools.py
+++ b/mcp_server_snowflake/tools.py
@@ -94,6 +94,7 @@ async def query_cortex_search(
 
     if response.status_code == 200:
         return response
+
     else:
         raise SnowflakeException(
             tool="Cortex Search",

--- a/mcp_server_snowflake/tools.py
+++ b/mcp_server_snowflake/tools.py
@@ -169,7 +169,6 @@ async def query_cortex_analyst(
     auth_manager,
     semantic_model: str,
     query: str,
-    username: str,
 ) -> dict:
     """
     Query Snowflake Cortex Analyst service for natural language to SQL conversion.
@@ -189,9 +188,6 @@ async def query_cortex_analyst(
         - "MY_DB.MY_SCH.MY_SEMANTIC_VIEW"
     query : str
         Natural language query string to submit to Cortex Analyst
-    username : str
-        Snowflake username for authentication.
-        This is used in the decorator to execute the query via SnowflakeConnectionManager.
 
     Returns
     -------
@@ -285,7 +281,6 @@ def create_cortex_analyst_wrapper(**kwargs):
                 auth_manager=snowflake_service,
                 semantic_model=service_details.get("semantic_model"),
                 query=query,
-                username=snowflake_service.username,
             )
 
     return cortex_analyst_wrapper

--- a/mcp_server_snowflake/utils.py
+++ b/mcp_server_snowflake/utils.py
@@ -323,7 +323,7 @@ class MissingArgumentsException(Exception):
         super().__init__(missing)
 
     def __str__(self):
-        missing_str = "\n\t\t".join([f"--{i}" for i in self.missing])
+        missing_str = "\n\t\t".join([f"{i}" for i in self.missing])
         message = f"""
         -----------------------------------------------------------------------------------
         Required arguments missing:

--- a/mcp_server_snowflake/utils.py
+++ b/mcp_server_snowflake/utils.py
@@ -122,7 +122,10 @@ class SnowflakeResponse:
             If connection fails or SQL execution encounters an error
         """
         # Forward any remaining kwargs to get_connection
-        with service.get_connection(use_dict_cursor=True, **kwargs) as (
+        # with service.get_connection(use_dict_cursor=True, **kwargs) as (
+        with service.get_connection(
+            use_dict_cursor=True, session_parameters=service.get_query_tag_param()
+        ) as (
             con,
             cur,
         ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-snowflake"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for Snowflake"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -768,7 +768,7 @@ cli = [
 
 [[package]]
 name = "mcp-server-snowflake"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
PR primarily expands all authentication to route through Snowflake Python Connector. Session parameters supported by connector are exposed via CLI flags and environment variables. Prior PAT flag and env variable are maintained and passed as a password credential. 

A Python connection is established at startup and maintained until application is closed. This Python connection provides the OAuth token used in REST API calls. Connection maintains query tagging for subsequent queries as well.

Username is removed from Cortex Analyst tooling.

Cleanup necessary in `auth.py` and `tests/`.