### PR TITLE
refactor: prevent double auth

### DIFF
--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -186,6 +186,14 @@ class SnowflakeService:
         else:
             return self.connection_params.get("account")
 
+    @staticmethod
+    def send_initial_query(connection: Any) -> None:
+        """
+        Send an initial query to the Snowflake service.
+        """
+        with connection.cursor() as cur:
+            cur.execute("SELECT 'MCP Server Snowflake'").fetchone()
+
     @property
     def is_spcs_container_environment(self) -> bool:
         """Check if running in SPCS container environment."""
@@ -194,8 +202,6 @@ class SnowflakeService:
     def _get_persistent_connection(
         self,
         session_parameters: Optional[Dict[str, Any]] = None,
-        major_version: Optional[int] = None,
-        minor_version: Optional[int] = None,
     ) -> Any:
         """
         Get a persistent Snowflake connection.
@@ -231,7 +237,9 @@ class SnowflakeService:
                 session_parameters=session_parameters,
                 client_session_keep_alive=True,
             )
-            return connection
+            if connection:  # Send zero compute query to capture query tag
+                self.send_initial_query(connection)
+                return connection
         except Exception as e:
             logger.error(f"Error establishing persistent Snowflake connection: {e}")
             raise
@@ -247,6 +255,9 @@ class SnowflakeService:
 
         This context manager ensures proper connection handling and cleanup.
         It automatically detects the environment and uses appropriate authentication.
+
+        If the connection is not established, it will be established with the specified parameters.
+        If the connection is already established, it will be used and session_parameters ignored.
 
         Parameters
         ----------
@@ -268,23 +279,24 @@ class SnowflakeService:
         """
 
         try:
-            connection = connect(
-                **self.connection_params,
-                session_parameters=session_parameters,
-                client_session_keep_alive=False,
-            )
+            if self.connection is None:
+                self.connection = connect(
+                    **self.connection_params,
+                    session_parameters=session_parameters,
+                    client_session_keep_alive=False,
+                )
 
             cursor = (
-                connection.cursor(DictCursor)
+                self.connection.cursor(DictCursor)
                 if use_dict_cursor
-                else connection.cursor()
+                else self.connection.cursor()
             )
 
             try:
-                yield connection, cursor
+                yield self.connection, cursor
             finally:
                 cursor.close()
-                connection.close()
+                # connection.close()
 
         except Exception as e:
             logger.error(f"Error establishing Snowflake connection: {e}")
@@ -536,8 +548,9 @@ def main():
         else:
             server.run(transport=snowflake_service.transport)
     finally:
-        if snowflake_service.connection:
-            snowflake_service.connection.close()
+        if snowflake_service:
+            if snowflake_service.connection:
+                snowflake_service.connection.close()
 
 
 if __name__ == "__main__":

--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -105,7 +105,6 @@ class SnowflakeService:
         self._is_spcs_container = is_running_in_spcs_container()
 
         self.unpack_service_specs()
-        self.set_query_tag()
         # Persist connection to avoid closing it after each request
         self.connection = self._get_persistent_connection()
 
@@ -219,10 +218,13 @@ class SnowflakeService:
             A Snowflake connection object
         """
         try:
+            query_tag_params = self.get_query_tag_param()
+
             if session_parameters is not None:
-                session_parameters.update(self.get_query_tag_param())
+                if query_tag_params:
+                    session_parameters.update(query_tag_params)
             else:
-                session_parameters = self.get_query_tag_param()
+                session_parameters = query_tag_params
 
             connection = connect(
                 **self.connection_params,
@@ -320,34 +322,6 @@ class SnowflakeService:
             return session_parameters
         else:
             return None
-
-    def set_query_tag(
-        self,
-    ) -> None:
-        """
-        Set the query tag for the Snowflake service.
-
-        Parameters
-        ----------
-        query_tag : dict[str, str], optional
-            Query tag dictionary
-        major_version : int, optional
-            Major version of the query tag
-        minor_version : int, optional
-            Minor version of the query tag
-        """
-
-        session_parameters = self.get_query_tag_param()
-
-        try:
-            # Test connection with the query tag
-            with self.get_connection(session_parameters=session_parameters) as (
-                con,
-                cur,
-            ):
-                cur.execute("SELECT 1").fetchone()
-        except Exception as e:
-            logger.warning(f"Error setting query tag: {e}")
 
 
 def get_var(var_name: str, env_var_name: str, args) -> Optional[str]:

--- a/mcp_server_snowflake/tests/test_service_config.py
+++ b/mcp_server_snowflake/tests/test_service_config.py
@@ -13,7 +13,7 @@
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -35,7 +35,7 @@ def mock_connection_params():
 def mock_snowflake_connect():
     """Mock the Snowflake connection for all tests."""
     with patch("mcp_server_snowflake.server.connect") as mock_connect:
-        mock_connect.return_value = Mock()
+        mock_connect.return_value = MagicMock()
         yield mock_connect
 
 


### PR DESCRIPTION
This should fix the issue with multiple DUO requests and clean up some of the query tag stuff where we will always be setting the query tag upon starting the server.