### PR TITLE
fix: suppress vendored deprecation warnings

### DIFF
--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -9,6 +9,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Suppress OpenSSL deprecation warnings from Snowflake connector's vendored urllib3
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    message=".*Attempting to mutate a Context after a Connection was created.*",
+    category=DeprecationWarning,
+)
+
 import argparse
 import json
 import logging

--- a/ruff.toml
+++ b/ruff.toml
@@ -48,6 +48,10 @@ unfixable = []
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
+[lint.per-file-ignores]
+# TODO: remove when we no longer need to suppress warnings before importing connector
+"mcp_server_snowflake/server.py" = ["E402"]
+
 [format]
 # Like Black, use double quotes for strings.
 quote-style = "double"


### PR DESCRIPTION
This PR will suppress the deprecation warnings on server start:

```.venv/lib/python3.13/site-packages/snowflake/connector/vendored/urllib3/contrib/pyopenssl.py:434: DeprecationWarning: Attempting to mutate a Context after a Connection was created. In the future, this will raise an exception```

The Snowflake connector uses a vendored version of urllib3 that hasn't been updated to work with the latest pyopenssl warning system. This is a known issue that should be addressed in an upstream release, at which point we could remove this.