### PR TITLE
docs: update Snowflake authentication documentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
     image: ${SNOWFLAKE_ACCOUNT}.registry.snowflakecomputing.com/cube_testing/public/awesome_images/mcp-server:latest
     container_name: mcp-server-snowflake
     environment:
-      - SNOWFLAKE_PAT=${SNOWFLAKE_PAT}
       - SNOWFLAKE_ACCOUNT=${SNOWFLAKE_ACCOUNT}
       - SNOWFLAKE_USER=${SNOWFLAKE_USER}
     volumes:

--- a/mcp_server_snowflake/__init__.py
+++ b/mcp_server_snowflake/__init__.py
@@ -27,11 +27,11 @@ variables and uses a YAML configuration file to define service specifications.
 Environment Variables
 ---------------------
 SNOWFLAKE_ACCOUNT : str
-    Snowflake account identifier (alternative to --account-identifier)
+    Snowflake account identifier (alternative to --account)
 SNOWFLAKE_USER : str
     Snowflake username (alternative to --username)
-SNOWFLAKE_PAT : str
-    Programmatic Access Token (alternative to --pat)
+SNOWFLAKE_PASSWORD : str
+    Password or Programmatic Access Token (alternative to --password)
 SERVICE_CONFIG_FILE : str
     Path to service configuration file (alternative to --service-config-file)
 """

--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -385,13 +385,13 @@ def get_var(var_name: str, env_var_name: str, args) -> Optional[str]:
     --------
     Get account identifier from args or environment:
 
-    >>> args = parser.parse_args(["--account-identifier", "myaccount"])
-    >>> get_var("account_identifier", "SNOWFLAKE_ACCOUNT", args)
+    >>> args = parser.parse_args(["--account", "myaccount"])
+    >>> get_var("account", "SNOWFLAKE_ACCOUNT", args)
     'myaccount'
 
     >>> os.environ["SNOWFLAKE_ACCOUNT"] = "myaccount"
     >>> args = parser.parse_args([])
-    >>> get_var("account_identifier", "SNOWFLAKE_ACCOUNT", args)
+    >>> get_var("account", "SNOWFLAKE_ACCOUNT", args)
     'myaccount'
     """
 
@@ -417,8 +417,8 @@ def create_snowflake_service():
     Raises
     ------
     MissingArgumentException
-        If required parameters (account_identifier and pat) are not provided
-        through either command line arguments or environment variables
+        If required parameters are not provided through either command line
+        arguments or environment variables
     SystemExit
         If argument parsing fails or help is requested
 


### PR DESCRIPTION
This PR refines the effort from yesterday to guide users more towards using the Snowflake Python connection documentation and relying less on CLI arguments.