### PR TITLE
Add help text to params

### DIFF
--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -410,7 +410,9 @@ def parse_arguments():
     login_params = get_login_params()
 
     for value in login_params.values():
-        parser.add_argument(*value[:-1], required=False, default=value[-1])
+        parser.add_argument(
+            *value[:-2], required=False, default=value[-2], help=value[-1]
+        )
 
     parser.add_argument(
         "--service-config-file",

--- a/mcp_server_snowflake/utils.py
+++ b/mcp_server_snowflake/utils.py
@@ -416,37 +416,91 @@ def get_login_params() -> dict:
     --------
     >>> params = get_login_params()
     >>> params["account"]
-    ['--account', '--account-identifier', os.getenv("SNOWFLAKE_ACCOUNT")]
+    ['--account', '--account-identifier', os.getenv("SNOWFLAKE_ACCOUNT"), "Your account identifier."]
     """
     # Dict of login params supported by snowflake connector api to establish connection
-    # {Key value name : [argparse argument name, default value]}
+    # {Key value name : [argparse argument name(s), default value, help]}
+    # Each argument can have 1-2 flag values. All arguments must have a default value and help.
     login_params = {  # TODO: Add help for each argument
         "account": [
             "--account",
             "--account-identifier",
             os.getenv("SNOWFLAKE_ACCOUNT"),
+            "Your account identifier. The account identifier does not include the snowflakecomputing.com suffix.",
         ],
-        "host": ["--host", os.getenv("SNOWFLAKE_HOST")],
-        "user": ["--user", "--username", os.getenv("SNOWFLAKE_USER")],
+        "host": ["--host", os.getenv("SNOWFLAKE_HOST"), "Host name."],
+        "user": [
+            "--user",
+            "--username",
+            os.getenv("SNOWFLAKE_USER"),
+            "Login name for the user.",
+        ],
         "password": [
             "--password",
             "--pat",
             os.getenv("SNOWFLAKE_PASSWORD") or os.getenv("SNOWFLAKE_PAT"),
+            "Password for the user.",
         ],
-        "role": ["--role", os.getenv("SNOWFLAKE_ROLE")],
-        "warehouse": ["--warehouse", os.getenv("SNOWFLAKE_WAREHOUSE")],
-        "passcode_in_password": ["--passcode-in-password", False],
-        "passcode": ["--passcode", os.getenv("SNOWFLAKE_PASSCODE")],
-        "private_key": ["--private-key", os.getenv("SNOWFLAKE_PRIVATE_KEY")],
+        "role": [
+            "--role",
+            os.getenv("SNOWFLAKE_ROLE"),
+            "Name of the default role to use.",
+        ],
+        "warehouse": [
+            "--warehouse",
+            os.getenv("SNOWFLAKE_WAREHOUSE"),
+            "Name of the default warehouse to use.",
+        ],
+        "passcode_in_password": [
+            "--passcode-in-password",
+            False,
+            "False by default. Set this to True if the MFA (Multi-Factor Authentication) passcode is embedded in the login password.",
+        ],
+        "passcode": [
+            "--passcode",
+            os.getenv("SNOWFLAKE_PASSCODE"),
+            "The passcode provided by Duo when using MFA (Multi-Factor Authentication) for login.",
+        ],
+        "private_key": [
+            "--private-key",
+            os.getenv("SNOWFLAKE_PRIVATE_KEY"),
+            "The private key used for authentication.",
+        ],
         "private_key_file": [
             "--private-key-file",
             os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE"),
+            "Specifies the path to the private key file for the specified user.",
         ],
         "private_key_pwd": [
             "--private-key-pwd",
             os.getenv("SNOWFLAKE_PRIVATE_KEY_PWD"),
+            "Specifies the passphrase to decrypt the private key file for the specified user.",
         ],
-        "authenticator": ["--authenticator", "snowflake"],
-        "connection_name": ["--connection-name", None],
+        "authenticator": [
+            "--authenticator",
+            "snowflake",
+            """Authenticator for Snowflake:
+
+snowflake (default) to use the internal Snowflake authenticator.
+
+externalbrowser to authenticate using your web browser and Okta, AD FS, or any other SAML 2.0-compliant identity provider (IdP) that has been defined for your account.
+
+https://<okta_account_name>.okta.com (i.e. the URL endpoint for your Okta account) to authenticate through native Okta.
+
+oauth to authenticate using OAuth. You must also specify the token parameter and set its value to the OAuth access token.
+
+username_password_mfa to authenticate with MFA token caching. For more details, see Using MFA token caching to minimize the number of prompts during authentication — optional.
+
+OAUTH_AUTHORIZATION_CODE to use the OAuth 2.0 Authorization Code flow.
+
+OAUTH_CLIENT_CREDENTIALS to use the OAuth 2.0 Client Credentials flow.
+
+If the value is not snowflake, the user and password parameters must be your login credentials for the IdP.""",
+        ],
+        "connection_name": [
+            "--connection-name",
+            None,
+            "Name of the connection in Snowflake configuration file to use.",
+        ],
     }
     return login_params

--- a/mcp_server_snowflake/utils.py
+++ b/mcp_server_snowflake/utils.py
@@ -444,12 +444,12 @@ def get_login_params() -> dict:
         "role": [
             "--role",
             os.getenv("SNOWFLAKE_ROLE"),
-            "Name of the default role to use.",
+            "Name of the role to use.",
         ],
         "warehouse": [
             "--warehouse",
             os.getenv("SNOWFLAKE_WAREHOUSE"),
-            "Name of the default warehouse to use.",
+            "Name of the warehouse to use.",
         ],
         "passcode_in_password": [
             "--passcode-in-password",


### PR DESCRIPTION
Help text added to CLI flags:

```
python mcp_server_snowflake/server.py -h

usage: server.py [-h] [--account ACCOUNT] [--host HOST] [--user USER] [--password PASSWORD] [--role ROLE]
                 [--warehouse WAREHOUSE] [--passcode-in-password PASSCODE_IN_PASSWORD]
                 [--passcode PASSCODE] [--private-key PRIVATE_KEY] [--private-key-file PRIVATE_KEY_FILE]
                 [--private-key-pwd PRIVATE_KEY_PWD] [--authenticator AUTHENTICATOR]
                 [--connection-name CONNECTION_NAME] [--service-config-file SERVICE_CONFIG_FILE]
                 [--transport {stdio,sse,streamable-http}]

Snowflake MCP Server

options:
  -h, --help            show this help message and exit
  --account, --account-identifier ACCOUNT
                        Your account identifier. The account identifier does not include the
                        snowflakecomputing.com suffix.
  --host HOST           Host name.
  --user, --username USER
                        Login name for the user.
  --password, --pat PASSWORD
                        Password for the user.
  --role ROLE           Name of the default role to use.
  --warehouse WAREHOUSE
                        Name of the default warehouse to use.
  --passcode-in-password PASSCODE_IN_PASSWORD
                        False by default. Set this to True if the MFA (Multi-Factor Authentication)
                        passcode is embedded in the login password.
  --passcode PASSCODE   The passcode provided by Duo when using MFA (Multi-Factor Authentication) for
                        login.
  --private-key PRIVATE_KEY
                        The private key used for authentication.
  --private-key-file PRIVATE_KEY_FILE
                        Specifies the path to the private key file for the specified user.
  --private-key-pwd PRIVATE_KEY_PWD
                        Specifies the passphrase to decrypt the private key file for the specified user.
  --authenticator AUTHENTICATOR
                        Authenticator for Snowflake: snowflake (default) to use the internal Snowflake
                        authenticator. externalbrowser to authenticate using your web browser and Okta, AD
                        FS, or any other SAML 2.0-compliant identity provider (IdP) that has been defined
                        for your account. https://<okta_account_name>.okta.com (i.e. the URL endpoint for
                        your Okta account) to authenticate through native Okta. oauth to authenticate using
                        OAuth. You must also specify the token parameter and set its value to the OAuth
                        access token. username_password_mfa to authenticate with MFA token caching. For
                        more details, see Using MFA token caching to minimize the number of prompts during
                        authentication — optional. OAUTH_AUTHORIZATION_CODE to use the OAuth 2.0
                        Authorization Code flow. OAUTH_CLIENT_CREDENTIALS to use the OAuth 2.0 Client
                        Credentials flow. If the value is not snowflake, the user and password parameters
                        must be your login credentials for the IdP.
  --connection-name CONNECTION_NAME
                        Name of the connection in Snowflake configuration file to use.
  --service-config-file SERVICE_CONFIG_FILE
                        Path to service specification file
  --transport {stdio,sse,streamable-http}
                        Transport for the MCP server
```