### PR TITLE
Add flags for new groups of tools to limit total count

### DIFF
--- a/mcp_server_snowflake/query_manager/prompts.py
+++ b/mcp_server_snowflake/query_manager/prompts.py
@@ -1,4 +1,4 @@
 query_tool_prompt = """
 Run a SQL query in Snowflake.
 DML and DDL queries are supported.
-Tool should only be used if other object tools do not suffice."""
+Tool should only be used if other tools do not suffice."""

--- a/services/configuration.yaml
+++ b/services/configuration.yaml
@@ -22,6 +22,10 @@ analyst_services: # List all Cortex Analyst semantic models/views
     semantic_model: "<semantic_yaml_or_view>" # Fully-qualify semantic YAML model or Semantic View
     description: > # Should start with "Analyst service that ..."
       "<Analyst service that ...>"
+other_services: # Set desired tool groups to True to enable tools for that group
+  object_manager: True # Perform basic operations against Snowflake's most common objects such as creation, dropping, updating, and more.
+  query_manager: True # Run LLM-generated SQL managed by user-configured permissions.
+  semantic_manager: True # Discover and query Snowflake Semantic Views and their components.
 sql_statement_permissions: # List SQL statements to explicitly allow (True) or disallow (False).
   # - All: True # To allow everything, uncomment and set All: True.
   - Alter: True


### PR DESCRIPTION
Users are highlighting MCP client warnings about tool counts when the Snowflake server is 1 of several connected. Our out of the box tool count is currently at ~58. Cursor, for example, warns at 80, previously 40. 

We will likely need to consolidate our object management tooling to start. In the meantime, this PR adds flags in the configuration file to directly hide tools for object management, sql execution, and semantic view querying.

For the most slimmed down setup, users can hide object management and semantic view querying and solely use Cortex Services (if desired) and direct sql querying.

PR also adds additional color to README about each "tool group", the new flags, and examples of passing semantic views/models to analyst services.