### PR TITLE
Raise value error if no service_config_file is passed

### DIFF
--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -100,6 +100,11 @@ class SnowflakeService:
         transport: str,
         connection_params: dict,
     ):
+        if service_config_file is None:
+            raise ValueError(
+                "service_config_file cannot be None. Please provide a path to the service configuration file."
+            )
+
         self.service_config_file = str(Path(service_config_file).expanduser().resolve())
         self.config_path_uri = Path(self.service_config_file).as_uri()
         self.transport = cast(Literal["stdio", "sse", "streamable-http"], transport)


### PR DESCRIPTION
Below is raised if no service_config_file is passed as part of CLI args:

`ValueError: service_config_file cannot be None. Please provide a path to the service configuration file.`