### PR TITLE
Return snowflake object directly if not string

### DIFF
--- a/mcp_server_snowflake/object_manager/tools.py
+++ b/mcp_server_snowflake/object_manager/tools.py
@@ -176,7 +176,7 @@ def parse_object(target_object: Any, obj_type: supported_objects):
         except Exception as e:
             raise e
     else:
-        return obj_type(**target_object)
+        return target_object
 
 
 def initialize_object_manager_tools(server: FastMCP, snowflake_service):


### PR DESCRIPTION
Some LLMs send objects through to tools instead of strings, which is the ideal but seemingly uncommon scenario. In that case, we want to pass the object directly as is to subsequent object mgmt functions that expect the Pydantic class directly.