### PR TITLE
Fix Private Key pwd typo

### DIFF
--- a/mcp_server_snowflake/utils.py
+++ b/mcp_server_snowflake/utils.py
@@ -506,9 +506,9 @@ def get_login_params() -> dict:
             os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE"),
             "Specifies the path to the private key file for the specified user.",
         ],
-        "private_key_pwd": [
-            "--private-key-pwd",
-            os.getenv("SNOWFLAKE_PRIVATE_KEY_PWD"),
+        "private_key_file_pwd": [
+            "--private-key-file-pwd",
+            os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE_PWD"),
             "Specifies the passphrase to decrypt the private key file for the specified user.",
         ],
         "authenticator": [


### PR DESCRIPTION
Fix for https://github.com/Snowflake-Labs/mcp/issues/91.

Looking at docs, the original parameter unpacking had a typo for `private_key_file_pwd`. 