### PR TITLE
ci: update MCP publishing workflow to remove pull request trigger

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -13,7 +13,6 @@
 name: Publish to MCP Registry
 
 on:
-  pull_request:
   release:
     types: [published]
   workflow_dispatch:  # Allow manual triggering
@@ -25,6 +24,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 10  # Prevent hanging jobs
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
We have had a few PR checks failing:

https://github.com/Snowflake-Labs/mcp/actions/runs/18139630801/job/51627047332?pr=121
https://github.com/Snowflake-Labs/mcp/actions/runs/18159542186/job/51687006747?pr=122

Proposing we make this change for now while we work through https://github.com/Snowflake-Labs/mcp/issues/116. 