### PR TITLE
chore: Remove dependency for manual trigger

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -26,16 +26,22 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Only run if the PyPI workflow succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Only run if the PyPI workflow succeeded OR if manually triggered
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
     - uses: actions/checkout@v4
 
     - name: Set VERSION from release tag
       run: |
-        # Get the tag that corresponds to the commit that triggered the PyPI workflow
+        # Get the tag that corresponds to the commit
         git fetch --tags
-        TAG=$(git describe --tags --exact-match ${{ github.event.workflow_run.head_sha }})
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          # For manual triggers, use the current commit
+          TAG=$(git describe --tags --exact-match HEAD || git describe --tags --abbrev=0)
+        else
+          # For workflow_run triggers, use the commit from the triggering workflow
+          TAG=$(git describe --tags --exact-match ${{ github.event.workflow_run.head_sha }})
+        fi
         # Extract version from tag (remove 'v' prefix if present)
         VERSION=${TAG#v}
         echo "VERSION=$VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
Now when you manually trigger the publish-mcp workflow, it will:
- Run without being skipped
- Have no prerequisites from the "Upload Python Package" workflow
- Automatically detect the version from the current commit's tag
- Still work correctly when triggered automatically after a successful PyPI upload