### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -30,6 +30,8 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch all history and tags for git describe to work
 
     - name: Set VERSION from release tag
       run: |

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -27,7 +27,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     # Only run if the PyPI workflow succeeded OR if manually triggered
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
- Fixed shallow clone issue: Added fetch-depth: 0 to the checkout step to ensure all git history and tags are available for the git describe command
- Added explicit event type checking: Enhanced the conditional logic to safely check github.event_name before accessing event-specific properties, preventing potential errors