### PR TITLE
Revert "feat: enable server host and port to be configurable via argparse or env"

### DIFF
--- a/mcp_server_snowflake/__init__.py
+++ b/mcp_server_snowflake/__init__.py
@@ -34,12 +34,6 @@ SNOWFLAKE_PASSWORD : str
     Password or Programmatic Access Token (alternative to --password)
 SERVICE_CONFIG_FILE : str
     Path to service configuration file (alternative to --service-config-file)
-SNOWFLAKE_MCP_HOST : str
-    Host address to bind the server to (alternative to --host, default: 0.0.0.0)
-SNOWFLAKE_MCP_PORT : str
-    Port number for the server to listen on (alternative to --port, default: 9000)
-SNOWFLAKE_MCP_ENDPOINT : str
-    Custom endpoint path for HTTP transports (alternative to --endpoint, default: /mcp)
 """
 
 from mcp_server_snowflake.server import main

--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -480,22 +480,9 @@ def parse_arguments():
         default="stdio",
     )
     parser.add_argument(
-        "--host",
-        required=False,
-        help="Host address to bind the server to (default: 0.0.0.0)",
-        default="0.0.0.0",
-    )
-    parser.add_argument(
-        "--port",
-        required=False,
-        type=int,
-        help="Port number for the server to listen on (default: 9000)",
-        default=9000,
-    )
-    parser.add_argument(
         "--endpoint",
         required=False,
-        help="Endpoint path for the MCP server (default: /mcp)",
+        help="Endpoint path for the MCP server (default: /snowflake-mcp)",
         default="/mcp",
     )
 
@@ -608,11 +595,11 @@ def main():
             "sse",
             "streamable-http",
         ]:
-            host = os.environ.get("SNOWFLAKE_MCP_HOST", args.host)
-            port = int(os.environ.get("SNOWFLAKE_MCP_PORT", str(args.port)))
             endpoint = os.environ.get("SNOWFLAKE_MCP_ENDPOINT", args.endpoint)
             logger.info(f"Starting server with transport: {args.transport}")
-            server.run(transport=args.transport, host=host, port=port, path=endpoint)
+            server.run(
+                transport=args.transport, host="0.0.0.0", port=9000, path=endpoint
+            )
         else:
             logger.info(f"Starting server with transport: {args.transport or 'stdio'}")
             server.run(transport=args.transport or "stdio")


### PR DESCRIPTION
Reverts Snowflake-Labs/mcp#131

PR introduced a bug
`argparse.ArgumentError: argument --host: conflicting option string: --host`

`--host` is added as a flag for `SNOWFLAKE_HOST` in `get_login_params()` in `utils.py`.

A different flag should be used for the endpoint host such as `host-address`.