### PR TITLE
Fix stdio authentication when using env var credentials

### DIFF
--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -284,16 +284,6 @@ class SnowflakeService:
                 logger.info("Using external authentication")
                 connection_params = self.connection_params.copy()
 
-            # We are passing session_parameters and client_session_keep_alive
-            # so we cannot rely on the connection to infer default connection name.
-            # So instead, if no explicit values passed via CLI, we replicate the same logic here
-            if not connection_params:
-                connection_params = {
-                    "connection_name": os.getenv(
-                        "SNOWFLAKE_DEFAULT_CONNECTION_NAME", "default"
-                    ),
-                }
-
             connection = connect(
                 **connection_params,
                 session_parameters=session_parameters,


### PR DESCRIPTION
## Resolves Issue
- #130 

## Fix: Remove incorrect `connection_name="default"` assignment for env-based auth

### Summary

This PR fixes a bug where the **Snowflake MCP server fails to connect via stdio transport** when using direct credentials (environment variables).
Previously, the server incorrectly injected a `connection_name="default"` into `connection_params`, causing the Snowflake Python connector to ignore provided env vars and attempt to resolve a named connection that didn’t exist in `connections.toml`.

### Problem

* When users provide credentials via `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USER`, `SNOWFLAKE_PASSWORD`, etc., the connector should authenticate directly.
* However, the `_get_persistent_connection` method unconditionally set `connection_name="default"` whenever `connection_params` appeared empty.
* With env vars present, this led to:

  ```
  Invalid connection_name 'default', known ones are []
  ```

  breaking stdio startup.

### Root Cause

The code conflated two different authentication modes:

1. **Direct auth** (via env vars / CLI params) → should not set `connection_name`.
2. **Named-connection auth** (via `connections.toml`) → must set `connection_name`.

By always setting `"default"`, the connector was forced into named-connection mode even when direct auth was intended.

### Fix

* **Removed lines 287–295 in `server.py`**:

  ```python
  # REMOVE THIS BLOCK
  if not connection_params:
      connection_params = {
          "connection_name": os.getenv(
              "SNOWFLAKE_DEFAULT_CONNECTION_NAME", "default"
          ),
      }
  ```
* Now:

  * Direct auth flows use env vars/params without interference.
  * Named-connection flows still work when `connection_name` is explicitly provided.
  * If no parameters are provided at all, the connector will fall back to its own default resolution logic (e.g., `connections.toml`, `SNOWFLAKE_DEFAULT_CONNECTION_NAME`).

### Impact

* ✅ Fixes stdio transport startup with env-based credentials.
* ✅ Keeps named-connection behavior intact.
* ✅ No regressions expected; behavior now aligns with Snowflake connector design.

### Repro

```bash
# Before (broken)
export SNOWFLAKE_ACCOUNT=xyz
export SNOWFLAKE_USER=abc
export SNOWFLAKE_PASSWORD=secret
snowflake-labs-mcp --service-config-file ~/.mcp/tools_config.yaml
# => ERROR Invalid connection_name 'default'

# After (fixed)
# Connects successfully using env vars
```
