### PR TITLE
fix: add health endpoint for compatibility with load balancers

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,24 @@ The MCP server supports multiple transport mechanisms. For detailed information 
 | `sse` (legacy) | Server-Sent Events | Streaming applications |
 | `streamable-http` | Streamable HTTP transport | Container deployments, remote servers |
 
+## Health Endpoint
+
+The MCP server provides a `/health` endpoint that returns a simple 200 OK response with a JSON body indicating the server's status. This endpoint is available when using HTTP-based transports (`http`, `sse`, `streamable-http`) and is useful for:
+
+- AWS Application Load Balancer (ALB) health checks
+- Kubernetes liveness and readiness probes
+- Docker health checks
+- Other orchestration systems
+
+**Example Response:**
+```json
+{
+  "status": "ok"
+}
+```
+
+This endpoint does not require authentication and can be accessed directly via HTTP GET:
+
 ## Usage
 
 ```bash
@@ -338,8 +356,11 @@ docker ps
 # Check container logs
 docker logs mcp-server-snowflake
 
-# Test endpoint (should return MCP server info)
+# Test MCP endpoint (should return MCP server info)
 curl http://localhost:9000/snowflake-mcp
+
+# Test health endpoint (should return {"status": "ok"})
+curl http://localhost:9000/health
 ```
 
 ## Docker Compose Deployment
@@ -387,8 +408,11 @@ docker-compose ps
 # View logs
 docker-compose logs
 
-# Test endpoint
+# Test MCP endpoint
 curl http://localhost:9000/snowflake-mcp
+
+# Test health endpoint
+curl http://localhost:9000/health
 ```
 
 ## Connecting MCP Clients to Containers

--- a/mcp_server_snowflake/server.py
+++ b/mcp_server_snowflake/server.py
@@ -581,6 +581,18 @@ def initialize_tools(snowflake_service: SnowflakeService, server: FastMCP):
             initialize_cortex_analyst_tool(server, snowflake_service)
 
 
+def add_health_endpoint(server: FastMCP):
+    """
+    Add a health endpoint to the server for compatibility with load balancers and orchestration systems.
+    
+    This endpoint returns a simple 200 OK response with a JSON body indicating the server's status.
+    It can be used by AWS ALB, Kubernetes, or other systems that expect a standard HTTP health check.
+    """
+    @server.app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+
 def main():
     args = parse_arguments()
 
@@ -588,6 +600,9 @@ def main():
 
     # Create server with lifespan that has access to args
     server = FastMCP("Snowflake MCP Server", lifespan=create_lifespan(args))
+    
+    # Add health endpoint for load balancers and orchestration systems
+    add_health_endpoint(server)
 
     try:
         logger.info("Starting Snowflake MCP Server...")

--- a/mcp_server_snowflake/tests/test_health_endpoint.py
+++ b/mcp_server_snowflake/tests/test_health_endpoint.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test for the health endpoint of the MCP server.
+"""
+import unittest
+import requests
+import subprocess
+import time
+import os
+import signal
+import sys
+from pathlib import Path
+
+
+class TestHealthEndpoint(unittest.TestCase):
+    """Test the health endpoint of the MCP server."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Start the MCP server before running tests."""
+        # Path to the configuration file
+        config_file = Path(__file__).parent.parent.parent / "services" / "configuration.yaml"
+        
+        # Start the server with HTTP transport
+        cls.server_process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "mcp_server_snowflake.server",
+                "--transport",
+                "http",
+                "--service-config-file",
+                str(config_file),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        
+        # Wait for the server to start
+        time.sleep(2)
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Stop the MCP server after running tests."""
+        if cls.server_process:
+            os.kill(cls.server_process.pid, signal.SIGTERM)
+            cls.server_process.wait()
+    
+    def test_health_endpoint(self):
+        """Test that the health endpoint returns a 200 OK response."""
+        response = requests.get("http://localhost:9000/health")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This commit adds a  endpoint to the MCP server that returns a 200 OK response with a JSON payload {"status": "ok"}. This endpoint enables compatibility with AWS ALB, Kubernetes, and other orchestration systems that require standard HTTP health checks.

Fixes #138