### PR TITLE
fix: Add missing __init__.py files and server wrapper

### DIFF
--- a/mcp_server_snowflake/cortex_services/__init__.py
+++ b/mcp_server_snowflake/cortex_services/__init__.py
@@ -1,0 +1,1 @@
+"""Cortex services module for MCP Snowflake server."""

--- a/mcp_server_snowflake/object_manager/__init__.py
+++ b/mcp_server_snowflake/object_manager/__init__.py
@@ -1,0 +1,1 @@
+"""Object manager module for MCP Snowflake server."""

--- a/mcp_server_snowflake/query_manager/__init__.py
+++ b/mcp_server_snowflake/query_manager/__init__.py
@@ -1,0 +1,1 @@
+"""Query manager module for MCP Snowflake server."""

--- a/mcp_server_snowflake/semantic_manager/__init__.py
+++ b/mcp_server_snowflake/semantic_manager/__init__.py
@@ -1,0 +1,1 @@
+"""Semantic manager module for MCP Snowflake server."""

--- a/run_server.py
+++ b/run_server.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+"""Wrapper script to run the Snowflake MCP server."""
+if __name__ == "__main__":
+    from mcp_server_snowflake import main
+    main()

--- a/services/minimal_config.yaml
+++ b/services/minimal_config.yaml
@@ -1,0 +1,34 @@
+# Minimal working configuration for MCP Snowflake Server
+# This allows the server to start without requiring actual Snowflake services
+
+# Empty service lists - no Cortex services configured
+agent_services: []
+search_services: []
+analyst_services: []
+
+# Enable basic tool groups
+other_services:
+  object_manager: true
+  query_manager: true
+  semantic_manager: true
+
+# SQL statement permissions - allow common operations
+sql_statement_permissions:
+  - Select: true
+  - Describe: true
+  - Show: true
+  - Use: true
+  - Create: true
+  - Drop: true
+  - Alter: true
+  - Insert: true
+  - Update: true
+  - Delete: true
+  - Merge: true
+  - TruncateTable: true
+  - Command: true
+  - Comment: true
+  - Commit: true
+  - Rollback: true
+  - Transaction: true
+  - Unknown: false


### PR DESCRIPTION
## Summary
This PR fixes critical import errors that prevented the MCP server from starting.

## Changes
- ✅ Added missing `__init__.py` files to 4 subdirectories:
  - `mcp_server_snowflake/cortex_services/__init__.py`
  - `mcp_server_snowflake/object_manager/__init__.py`
  - `mcp_server_snowflake/query_manager/__init__.py`
  - `mcp_server_snowflake/semantic_manager/__init__.py`
- ✅ Created `run_server.py` wrapper script to work around console script import issues
- ✅ Added `services/minimal_config.yaml` as a working configuration template

## Problem
Without the `__init__.py` files, Python cannot import from these subdirectories, causing `ModuleNotFoundError` when the server tries to start:
```
from mcp_server_snowflake.cortex_services.tools import initialize_cortex_agent_tool
ModuleNotFoundError: No module named 'mcp_server_snowflake.cortex_services'
```

## Solution
Added empty `__init__.py` files to make the directories proper Python packages, allowing imports to work correctly.

## Testing
- ✅ Server starts successfully with `uv run python run_server.py --help`
- ✅ MCP server connects successfully in Claude Desktop
- ✅ MCP server connects successfully in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)