### PR TITLE
fix: Add AS alias to semantic view query to preserve column names

### DIFF
--- a/mcp_server_snowflake/semantic_manager/tools.py
+++ b/mcp_server_snowflake/semantic_manager/tools.py
@@ -185,11 +185,12 @@ def write_semantic_view_query(
     bindvars = [f"{database_name}.{schema_name}.{view_name}"]
 
     # Add clauses in order (affects output column order)
+    # Use AS alias to preserve column names when using bind variables
     if dimensions:
         statement += " DIMENSIONS"
         for index, expr in enumerate(dimensions):
             is_last = index == len(dimensions) - 1
-            statement += " identifier(?)"
+            statement += f" identifier(?) AS {expr.name}"
             bindvars.extend([f"{expr.table}.{expr.name}"])
             if not is_last:
                 statement += ","
@@ -198,7 +199,7 @@ def write_semantic_view_query(
         statement += " METRICS"
         for index, expr in enumerate(metrics):
             is_last = index == len(metrics) - 1
-            statement += " identifier(?)"
+            statement += f" identifier(?) AS {expr.name}"
             bindvars.extend([f"{expr.table}.{expr.name}"])
             if not is_last:
                 statement += ","
@@ -207,7 +208,7 @@ def write_semantic_view_query(
         statement += " FACTS"
         for index, expr in enumerate(facts):
             is_last = index == len(facts) - 1
-            statement += " identifier(?)"
+            statement += f" identifier(?) AS {expr.name}"
             bindvars.extend([f"{expr.table}.{expr.name}"])
             if not is_last:
                 statement += ","


### PR DESCRIPTION
## Summary

When using bind variables with `identifier(?)` in SEMANTIC_VIEW queries, Snowflake returns numeric column names (e.g., `"2"`) instead of the actual dimension/metric/fact names. This causes WHERE and ORDER BY clauses to fail because they reference non-existent column names.

## Changes

- Add `AS {expr.name}` alias to each identifier in DIMENSIONS, METRICS, and FACTS clauses
- This preserves column names while maintaining the security benefits of using bind variables

## Example

**Before** (Error):
```sql
SELECT * FROM SEMANTIC_VIEW (identifier(?) DIMENSIONS identifier(?))
WHERE column_name = 'value'
-- Error: invalid identifier 'column_name'
-- Result columns have numeric names like "2" instead of actual names
```

**After** (Success):
```sql
SELECT * FROM SEMANTIC_VIEW (identifier(?) DIMENSIONS identifier(?) AS column_name)
WHERE column_name = 'value'
-- ✓ Works correctly
-- Result columns have proper names
```