### PR TITLE
fix(security): wire semantic middleware and fix if/elif logic in vali…

### DIFF
--- a/mcp_server_snowflake/object_manager/tools.py
+++ b/mcp_server_snowflake/object_manager/tools.py
@@ -310,8 +310,7 @@ def validate_object_tool(
     # User has not added any permissions, so we default to disallowing all object actions
     if len(sql_allow_list) == 0 and len(sql_disallow_list) == 0:
         valid = False
-
-    if func_type in sql_allow_list:
+    elif func_type in sql_allow_list:
         valid = True
     elif func_type in sql_disallow_list:
         valid = False

--- a/mcp_server_snowflake/semantic_manager/tools.py
+++ b/mcp_server_snowflake/semantic_manager/tools.py
@@ -214,7 +214,6 @@ def write_semantic_view_query(
 
     statement += ")"  # Close out the semantic sub-select
 
-    # Add optional clauses
     if where_clause:
         statement += f" WHERE {where_clause}"
 
@@ -278,7 +277,7 @@ def validate_semantic_view_tool(
     # User has not added any permissions, so we default to disallowing all object actions
     if len(sql_allow_list) == 0 and len(sql_disallow_list) == 0:
         valid = False
-    if func_type in sql_allow_list:
+    elif func_type in sql_allow_list:
         valid = True
     elif func_type in sql_disallow_list:
         valid = False

--- a/mcp_server_snowflake/server_utils.py
+++ b/mcp_server_snowflake/server_utils.py
@@ -4,6 +4,7 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 
 from mcp_server_snowflake.object_manager.tools import validate_object_tool
 from mcp_server_snowflake.query_manager.tools import validate_sql_type
+from mcp_server_snowflake.semantic_manager.tools import validate_semantic_view_tool
 
 
 class CheckQueryType(Middleware):
@@ -31,6 +32,11 @@ class CheckQueryType(Middleware):
             "drop"
         ):
             statement_type, valid = validate_object_tool(
+                tool_name, self.sql_allow_list, self.sql_disallow_list
+            )
+
+        elif "semantic" in tool_name.lower():
+            statement_type, valid = validate_semantic_view_tool(
                 tool_name, self.sql_allow_list, self.sql_disallow_list
             )
 


### PR DESCRIPTION
Fixes #166 

Wire `validate_semantic_view_tool` into `CheckQueryType` middleware so semantic tools respect `sql_statement_permissions`. Fix `if`/`elif` logic error in both `validate_semantic_view_tool` and `validate_object_tool` to match the correct pattern used in `validate_sql_type`.

Bug 3 (unvalidated `where_clause`/`order_by` interpolation) is reported in the issue but not addressed in this PR.