### PR TITLE
fix(cortex_agent): fix SSE response parsing for Cortex Agent API

### DIFF
--- a/mcp_server_snowflake/cortex_services/tools.py
+++ b/mcp_server_snowflake/cortex_services/tools.py
@@ -76,7 +76,6 @@ async def query_cortex_agent(
     payload = {
         "messages": [{"role": "user", "content": [{"type": "text", "text": query}]}],
         "tool_choice": {"type": "auto"},
-        "stream": False,  # Ignored by Agent API
     }
     try:
         response = requests.post(

--- a/mcp_server_snowflake/utils.py
+++ b/mcp_server_snowflake/utils.py
@@ -309,11 +309,11 @@ class SnowflakeResponse:
                 # If the next line is 'data:', it contains the JSON payload we need
                 json_data = line[len("data: ") :]
                 try:
-                    final_text = (
-                        json.loads(json_data)
-                        .get("content", [{}])[-1]
-                        .get("text", "No final response found.")
-                    )
+                    content = json.loads(json_data).get("content", [])
+                    final_text = "No final response found."
+                    for item in content:
+                        if item.get("type") == "text" and "text" in item:
+                            final_text = item["text"]
                     # Return formatted AgentResponse for consistency with other parsers
                     response = AgentResponse(results=final_text)
                     return response.model_dump_json()


### PR DESCRIPTION
## Summary

- **Remove `stream: False`** from the Cortex Agent request payload. This parameter caused Snowflake to return plain JSON instead of SSE, but `parse_agent_response()` expects SSE format with `event: response` markers. Without streaming, the parser found zero events and always returned `"No final response found."`.
- **Fix `content[-1]` assumption** in `parse_agent_response()`. The response `content` array contains multiple types (`thinking`, `tool_use`, `tool_result`, `text`, `suggested_queries`). The last item is `suggested_queries`, not `text`. The fix iterates the array and explicitly finds the item with `type == "text"`.

## Root Cause

The `cortex_agent` tool always returned `{"results": "No final response found."}` due to two compounding bugs:

1. **`tools.py:79`** — `"stream": False` was included with the comment "Ignored by Agent API", but it is **not** ignored. Snowflake returns `Content-Type: application/json` (a single JSON blob) instead of `text/event-stream` (SSE). The parser then iterates over JSON lines looking for `event: response` and never finds it.

2. **`utils.py:312-316`** — Even when streaming works correctly, `content[-1].get("text")` grabs the wrong item. The `suggested_queries` content type appears after `text` in the array, so the last element has no `text` field and falls back to the default `"No final response found."`.

## Test plan

- [x] Verified standalone REST call to Cortex Agent with streaming enabled returns valid SSE with `event: response`
- [x] Verified the `event: response` data payload contains a `content` array where the `text` item is NOT the last element
- [x] Verified the fix end-to-end: `cortex_agent` MCP tool now returns actual agent responses
- [x] Verified requests appear in Snowflake Cortex Agent Activity monitoring page