### PR TITLE
fix: pin fakeredis <2.35.0 to avoid FakeConnection import error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "snowflake-connector-python>=3.15.0,<4.0.0",
     "snowflake-core>=1.0.0,<2.0.0",
     "sqlglot>=27.8.0,<30.0.0",
+    "fakeredis>=2.30.0,<2.35.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
- fakeredis 2.35.0 renamed FakeConnection to FakeRedisConnection
- pydocket dependency still uses old import name
- pin fakeredis to 2.34.x until pydocket is updated

Fixes the MCP server startup error:
ImportError: cannot import name 'FakeConnection' from 'fakeredis.aioredis'