### PR TITLE
Bump version to 1.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snowflake-labs-mcp"
-version = "1.4.0"
+version = "1.4.1"
 description = "MCP server for Snowflake"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -2080,7 +2080,7 @@ wheels = [
 
 [[package]]
 name = "snowflake-labs-mcp"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- Fix failed PyPI publish by bumping package version to 1.4.1. The previous release tag `v.1.4.1` referenced a build with version `1.4.0`, which already existed on PyPI.

## Test plan
- [ ] Verify `pyproject.toml` version is `1.4.1`
- [ ] Verify `uv.lock` is in sync
- [ ] After merge, create new release tag and confirm publish succeeds

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)