### PR TITLE
fix #188

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Snowflake Cortex AI Model Context Protocol (MCP) Server
+statement_type# Snowflake Cortex AI Model Context Protocol (MCP) Server
 
 <a href="https://emerging-solutions-toolbox.streamlit.app/">
     <img src="https://github.com/user-attachments/assets/aa206d11-1d86-4f32-8a6d-49fe9715b098" alt="image" width="150" align="right";">
@@ -86,6 +86,7 @@ sql_statement_permissions: # List SQL statements to explicitly allow (True) or d
   - Merge: True
   - Rollback: True
   - Select: True
+  - Show: True
   - Transaction: True
   - TruncateTable: True
   - Unknown: False # To allow unknown or unmapped statement types, set Unknown: True.

--- a/mcp_server_snowflake/query_manager/tools.py
+++ b/mcp_server_snowflake/query_manager/tools.py
@@ -74,6 +74,9 @@ def get_statement_type(sql_string):
 
         # The expression type is the class of the root node.
         statement_type = type(expression_tree).__name__
+        # Treat SHOW ... command as a separate type, to allow SHOW [AGENT] as an example
+        if statement_type == "Command" and sql_string.strip().upper().startswith("SHOW"):
+            return "Show"
 
         return statement_type
     except (

--- a/mcp_server_snowflake/tests/test_query_manager_tools.py
+++ b/mcp_server_snowflake/tests/test_query_manager_tools.py
@@ -54,6 +54,8 @@ class TestGetStatementType:
     def test_column_colon_path_with_cast(self):
         assert get_statement_type("SELECT v:city::string FROM t") == "Select"
 
+    def test_show_agent(self):
+        assert get_statement_type("SHOW AGENTS IN SCHEMA ABC") == "Show"
 
 class TestSnowflakeSpecificSyntax:
     """Additional Snowflake dialect coverage: COPY INTO, LATERAL FLATTEN, etc."""


### PR DESCRIPTION
The current implementation categorizes the new `SHOW AGENT` syntax under the Command SQL statement type. This creates a security friction point because the Command type also encompasses high-risk DDL and DML operations like **DROP**, **DELETE**, and **UPDATE**.

In production environments, users are often restricted from executing destructive commands, yet they still require the ability to describe or list resources (in this case agents).
We need to introduce a distinct sql_statement_permissions:Show category. This separation would allow people to safely grant "read-only" metadata access without exposing the database to accidental data loss or structural changes.
Moving **SHOW** queries to their own permission type ensures a more granular and secure access control model.

Closes #188 